### PR TITLE
Separate CSS and JavaScript from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,298 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Captured Moments &mdash; Photography Portfolio</title>
-    <style>
-        :root {
-            color-scheme: light dark;
-            --accent: #ff7a59;
-            --accent-dark: #d95c3d;
-            --bg: #0f172a;
-            --bg-light: #f8fafc;
-            --text-dark: #0f172a;
-            --text-light: #f8fafc;
-            --muted: #64748b;
-            --shadow: 0 18px 45px rgba(15, 23, 42, 0.15);
-            font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
-        }
+    <link rel="stylesheet" href="public/css/style.css" />
+    <script src="public/js/main.js" defer></script>
 
-        * {
-            box-sizing: border-box;
-        }
-
-        body {
-            margin: 0;
-            background: linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(15, 23, 42, 0.92) 45%, rgba(15, 23, 42, 0.85));
-            color: var(--text-light);
-        }
-
-        header {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 1rem clamp(2rem, 6vw, 6rem);
-            background: rgba(15, 23, 42, 0.85);
-            backdrop-filter: blur(12px);
-            z-index: 1000;
-            box-shadow: 0 2px 24px rgba(15, 23, 42, 0.2);
-        }
-
-        .logo {
-            font-weight: 700;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-        }
-
-        nav ul {
-            list-style: none;
-            display: flex;
-            gap: 1.5rem;
-            margin: 0;
-            padding: 0;
-        }
-
-        nav a {
-            color: inherit;
-            text-decoration: none;
-            font-weight: 500;
-            position: relative;
-            padding-bottom: 0.25rem;
-        }
-
-        nav a::after {
-            content: "";
-            position: absolute;
-            left: 0;
-            bottom: 0;
-            width: 100%;
-            height: 2px;
-            background: var(--accent);
-            transform: scaleX(0);
-            transform-origin: right;
-            transition: transform 0.25s ease;
-        }
-
-        nav a:hover::after,
-        nav a.active::after {
-            transform: scaleX(1);
-            transform-origin: left;
-        }
-
-        main {
-            padding-top: 5rem;
-        }
-
-        section {
-            min-height: 100vh;
-            display: grid;
-            align-items: center;
-            padding: clamp(4rem, 12vw, 8rem) clamp(2rem, 8vw, 8rem);
-            gap: 3rem;
-        }
-
-        .hero {
-            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-            column-gap: clamp(2rem, 6vw, 5rem);
-        }
-
-        .hero h1 {
-            font-size: clamp(2.8rem, 6vw, 4.5rem);
-            margin-bottom: 1.5rem;
-        }
-
-        .hero p {
-            line-height: 1.7;
-            color: var(--muted);
-            margin-bottom: 2rem;
-        }
-
-        .cta-group {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 1rem;
-        }
-
-        .btn {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            padding: 0.85rem 1.8rem;
-            border-radius: 999px;
-            font-weight: 600;
-            text-decoration: none;
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
-        }
-
-        .btn-primary {
-            background: var(--accent);
-            color: var(--text-dark);
-            box-shadow: var(--shadow);
-        }
-
-        .btn-primary:hover {
-            background: var(--accent-dark);
-            transform: translateY(-2px);
-        }
-
-        .btn-secondary {
-            border: 1px solid rgba(248, 250, 252, 0.2);
-            color: var(--text-light);
-            backdrop-filter: blur(6px);
-        }
-
-        .hero-image {
-            border-radius: 28px;
-            overflow: hidden;
-            box-shadow: var(--shadow);
-        }
-
-        .hero-image img {
-            width: 100%;
-            display: block;
-        }
-
-        .section-title {
-            font-size: clamp(2.2rem, 4vw, 3rem);
-            margin-bottom: 1rem;
-        }
-
-        .about {
-            background: var(--bg-light);
-            color: var(--text-dark);
-            border-top-left-radius: 48px;
-            border-top-right-radius: 48px;
-        }
-
-        .about p {
-            color: var(--muted);
-            line-height: 1.8;
-        }
-
-        .about-grid {
-            display: grid;
-            gap: 2.5rem;
-            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-        }
-
-        .stat {
-            background: white;
-            border-radius: 24px;
-            padding: 2rem;
-            box-shadow: var(--shadow);
-        }
-
-        .stat h3 {
-            margin: 0;
-            font-size: 2.25rem;
-            color: var(--accent);
-        }
-
-        .stat p {
-            margin-top: 0.75rem;
-            color: #334155;
-        }
-
-        .portfolio {
-            background: var(--bg);
-        }
-
-        .portfolio-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-            gap: 2rem;
-        }
-
-        .portfolio-card {
-            background: rgba(15, 23, 42, 0.6);
-            border-radius: 24px;
-            overflow: hidden;
-            box-shadow: var(--shadow);
-            transition: transform 0.25s ease, box-shadow 0.25s ease;
-        }
-
-        .portfolio-card:hover {
-            transform: translateY(-6px);
-            box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
-        }
-
-        .portfolio-card img {
-            width: 100%;
-            height: 220px;
-            object-fit: cover;
-        }
-
-        .portfolio-card div {
-            padding: 1.75rem;
-        }
-
-        .contact {
-            background: var(--bg-light);
-            color: var(--text-dark);
-            border-bottom-left-radius: 48px;
-            border-bottom-right-radius: 48px;
-        }
-
-        .contact-wrapper {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-            gap: 3rem;
-            align-items: start;
-        }
-
-        form {
-            background: white;
-            border-radius: 24px;
-            padding: 2.5rem;
-            box-shadow: var(--shadow);
-            display: grid;
-            gap: 1rem;
-        }
-
-        label {
-            font-weight: 600;
-        }
-
-        input,
-        textarea {
-            padding: 0.85rem 1rem;
-            border-radius: 12px;
-            border: 1px solid rgba(148, 163, 184, 0.4);
-            font: inherit;
-            resize: vertical;
-        }
-
-        textarea {
-            min-height: 160px;
-        }
-
-        footer {
-            text-align: center;
-            padding: 3rem 1rem;
-            color: rgba(248, 250, 252, 0.7);
-        }
-
-        @media (max-width: 640px) {
-            header {
-                flex-direction: column;
-                gap: 1rem;
-            }
-
-            nav ul {
-                gap: 1rem;
-            }
-
-            section {
-                padding: 6rem 1.5rem;
-            }
-
-            .portfolio-card img {
-                height: 200px;
-            }
-        }
-    </style>
 </head>
 <body>
 <header>
@@ -357,7 +68,7 @@
     <section id="portfolio" class="portfolio">
         <div>
             <h2>Portfolio</h2>
-            <p style="max-width: 640px; color: var(--muted);">
+            <p class="section-description">
                 A curated look at client stories&mdash;from luminous destination weddings to editorial portraiture and
                 lifestyle campaigns. Each gallery is shot on full-frame digital and 35mm film for layered texture.
             </p>
@@ -402,13 +113,13 @@
         <div class="contact-wrapper">
             <div>
                 <h2>Contact Me</h2>
-                <p style="color: var(--muted); line-height: 1.8;">
+                <p class="section-description">
                     Ready to create something beautiful together? Share your vision, and I’ll be in touch within two
                     business days with availability, location ideas, and tailored packages.
                 </p>
-                <div style="display: grid; gap: 1rem; margin-top: 2rem;">
-                    <span>Email: <a style="color: inherit; text-decoration: underline;" href="mailto:hello@capturedmoments.co">hello@capturedmoments.co</a></span>
-                    <span>Phone: <a style="color: inherit; text-decoration: none;" href="tel:+13125551234">+1 (312) 555-1234</a></span>
+                <div class="contact-details">
+                    <span>Email: <a class="contact-link contact-link--underline" href="mailto:hello@capturedmoments.co">hello@capturedmoments.co</a></span>
+                    <span>Phone: <a class="contact-link" href="tel:+13125551234">+1 (312) 555-1234</a></span>
                     <span>Studio: 902 Aurora Ave, Suite 210, Chicago, IL</span>
                 </div>
             </div>
@@ -430,38 +141,6 @@
 <footer>
     &copy; <span id="current-year"></span> Captured Moments Photography. All rights reserved.
 </footer>
-<script>
-    const links = document.querySelectorAll('.nav-link');
 
-    function setActiveLink() {
-        const fromTop = window.scrollY + 120;
-        links.forEach((link) => {
-            const section = document.querySelector(link.getAttribute('href'));
-            if (!section) return;
-            const top = section.offsetTop;
-            const bottom = top + section.offsetHeight;
-            link.classList.toggle('active', fromTop >= top && fromTop < bottom);
-        });
-    }
-
-    links.forEach((link) => {
-        link.addEventListener('click', (event) => {
-            event.preventDefault();
-            const target = document.querySelector(link.getAttribute('href'));
-            if (target) {
-                window.scrollTo({ top: target.offsetTop - 80, behavior: 'smooth' });
-            }
-        });
-    });
-
-    setActiveLink();
-    window.addEventListener('scroll', setActiveLink);
-
-    const year = new Date().getFullYear();
-    const yearSpan = document.getElementById('current-year');
-    if (yearSpan) {
-        yearSpan.textContent = year;
-    }
-</script>
 </body>
 </html>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,311 @@
+:root {
+    color-scheme: light dark;
+    --accent: #ff7a59;
+    --accent-dark: #d95c3d;
+    --bg: #0f172a;
+    --bg-light: #f8fafc;
+    --text-dark: #0f172a;
+    --text-light: #f8fafc;
+    --muted: #64748b;
+    --shadow: 0 18px 45px rgba(15, 23, 42, 0.15);
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(15, 23, 42, 0.92) 45%, rgba(15, 23, 42, 0.85));
+    color: var(--text-light);
+}
+
+header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem clamp(2rem, 6vw, 6rem);
+    background: rgba(15, 23, 42, 0.85);
+    backdrop-filter: blur(12px);
+    z-index: 1000;
+    box-shadow: 0 2px 24px rgba(15, 23, 42, 0.2);
+}
+
+.logo {
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+nav ul {
+    list-style: none;
+    display: flex;
+    gap: 1.5rem;
+    margin: 0;
+    padding: 0;
+}
+
+nav a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 500;
+    position: relative;
+    padding-bottom: 0.25rem;
+}
+
+nav a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background: var(--accent);
+    transform: scaleX(0);
+    transform-origin: right;
+    transition: transform 0.25s ease;
+}
+
+nav a:hover::after,
+nav a.active::after {
+    transform: scaleX(1);
+    transform-origin: left;
+}
+
+main {
+    padding-top: 5rem;
+}
+
+section {
+    min-height: 100vh;
+    display: grid;
+    align-items: center;
+    padding: clamp(4rem, 12vw, 8rem) clamp(2rem, 8vw, 8rem);
+    gap: 3rem;
+}
+
+.hero {
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    column-gap: clamp(2rem, 6vw, 5rem);
+}
+
+.hero h1 {
+    font-size: clamp(2.8rem, 6vw, 4.5rem);
+    margin-bottom: 1.5rem;
+}
+
+.hero p {
+    line-height: 1.7;
+    color: var(--muted);
+    margin-bottom: 2rem;
+}
+
+.cta-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.8rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary {
+    background: var(--accent);
+    color: var(--text-dark);
+    box-shadow: var(--shadow);
+}
+
+.btn-primary:hover {
+    background: var(--accent-dark);
+    transform: translateY(-2px);
+}
+
+.btn-secondary {
+    border: 1px solid rgba(248, 250, 252, 0.2);
+    color: var(--text-light);
+    backdrop-filter: blur(6px);
+}
+
+.hero-image {
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: var(--shadow);
+}
+
+.hero-image img {
+    width: 100%;
+    display: block;
+}
+
+.section-title {
+    font-size: clamp(2.2rem, 4vw, 3rem);
+    margin-bottom: 1rem;
+}
+
+.about {
+    background: var(--bg-light);
+    color: var(--text-dark);
+    border-top-left-radius: 48px;
+    border-top-right-radius: 48px;
+}
+
+.about p {
+    color: var(--muted);
+    line-height: 1.8;
+}
+
+.about-grid {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.stat {
+    background: white;
+    border-radius: 24px;
+    padding: 2rem;
+    box-shadow: var(--shadow);
+}
+
+.stat h3 {
+    margin: 0;
+    font-size: 2.25rem;
+    color: var(--accent);
+}
+
+.stat p {
+    margin-top: 0.75rem;
+    color: #334155;
+}
+
+.portfolio {
+    background: var(--bg);
+}
+
+.portfolio-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2rem;
+}
+
+.portfolio-card {
+    background: rgba(15, 23, 42, 0.6);
+    border-radius: 24px;
+    overflow: hidden;
+    box-shadow: var(--shadow);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.portfolio-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+}
+
+.portfolio-card img {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
+}
+
+.portfolio-card div {
+    padding: 1.75rem;
+}
+
+.section-description {
+    max-width: 40rem;
+    color: var(--muted);
+    line-height: 1.8;
+}
+
+.contact-details {
+    display: grid;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.contact-link {
+    color: inherit;
+    text-decoration: none;
+}
+
+.contact-link--underline {
+    text-decoration: underline;
+}
+
+.contact {
+    background: var(--bg-light);
+    color: var(--text-dark);
+    border-bottom-left-radius: 48px;
+    border-bottom-right-radius: 48px;
+}
+
+.contact-wrapper {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 3rem;
+    align-items: start;
+}
+
+form {
+    background: white;
+    border-radius: 24px;
+    padding: 2.5rem;
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 1rem;
+}
+
+label {
+    font-weight: 600;
+}
+
+input,
+textarea {
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    font: inherit;
+    resize: vertical;
+}
+
+textarea {
+    min-height: 160px;
+}
+
+footer {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: rgba(248, 250, 252, 0.7);
+}
+
+@media (max-width: 640px) {
+    header {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    nav ul {
+        gap: 1rem;
+    }
+
+    section {
+        padding: 6rem 1.5rem;
+    }
+
+    .portfolio-card img {
+        height: 200px;
+    }
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,0 +1,31 @@
+const links = document.querySelectorAll('.nav-link');
+
+function setActiveLink() {
+    const fromTop = window.scrollY + 120;
+    links.forEach((link) => {
+        const section = document.querySelector(link.getAttribute('href'));
+        if (!section) return;
+        const top = section.offsetTop;
+        const bottom = top + section.offsetHeight;
+        link.classList.toggle('active', fromTop >= top && fromTop < bottom);
+    });
+}
+
+links.forEach((link) => {
+    link.addEventListener('click', (event) => {
+        event.preventDefault();
+        const target = document.querySelector(link.getAttribute('href'));
+        if (target) {
+            window.scrollTo({ top: target.offsetTop - 80, behavior: 'smooth' });
+        }
+    });
+});
+
+setActiveLink();
+window.addEventListener('scroll', setActiveLink);
+
+const year = new Date().getFullYear();
+const yearSpan = document.getElementById('current-year');
+if (yearSpan) {
+    yearSpan.textContent = year;
+}


### PR DESCRIPTION
## Summary
- move the inline stylesheet into `public/css/style.css` and link it from `index.html`
- extract the existing navigation and footer logic into `public/js/main.js` and load it with `defer`
- replace inline styling in the portfolio and contact sections with reusable utility classes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d45380cd8083269c28d8acdee68bb6