### PR TITLE
Refine layout tiles and card styling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -8,6 +8,12 @@
     --text-light: #fdfdf9;
     --muted: #637262;
     --shadow: 0 18px 45px rgba(47, 58, 47, 0.12);
+    --shadow-strong: 0 24px 60px rgba(47, 58, 47, 0.18);
+    --radius-xl: 32px;
+    --radius-lg: 24px;
+    --radius-md: 18px;
+    --section-gap: clamp(3rem, 8vw, 6rem);
+    --card-padding: clamp(1.75rem, 3vw, 2.5rem);
     font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
 }
 
@@ -116,7 +122,7 @@ section {
     display: grid;
     align-items: center;
     padding: clamp(4rem, 12vw, 8rem) clamp(2rem, 8vw, 8rem);
-    gap: 3rem;
+    gap: var(--section-gap);
 }
 
 .hero {
@@ -177,7 +183,7 @@ section {
 }
 
 .hero-image {
-    border-radius: 28px;
+    border-radius: var(--radius-xl);
     overflow: hidden;
     box-shadow: var(--shadow);
 }
@@ -206,25 +212,29 @@ section {
 
 .about-grid {
     display: grid;
-    gap: 2.5rem;
+    gap: calc(var(--section-gap) * 0.8);
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .stat {
     background: #fdfcf8;
-    border-radius: 24px;
-    padding: 2rem;
+    border-radius: var(--radius-lg);
+    padding: var(--card-padding);
     box-shadow: var(--shadow);
+    display: grid;
+    gap: 0.75rem;
+    text-align: left;
+    min-height: clamp(200px, 28vw, 240px);
 }
 
 .stat h3 {
     margin: 0;
-    font-size: 2.25rem;
+    font-size: clamp(2.1rem, 3.5vw, 2.6rem);
     color: var(--accent);
 }
 
 .stat p {
-    margin-top: 0.75rem;
+    margin: 0;
     color: #475347;
 }
 
@@ -235,30 +245,46 @@ section {
 .portfolio-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 2rem;
+    gap: var(--section-gap);
 }
 
 .portfolio-card {
     background: rgba(255, 255, 255, 0.85);
-    border-radius: 24px;
+    border-radius: var(--radius-lg);
     overflow: hidden;
     box-shadow: var(--shadow);
     transition: transform 0.25s ease, box-shadow 0.25s ease;
+    display: flex;
+    flex-direction: column;
 }
 
 .portfolio-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 24px 60px rgba(47, 58, 47, 0.18);
+    box-shadow: var(--shadow-strong);
 }
 
 .portfolio-card img {
     width: 100%;
-    height: 220px;
+    aspect-ratio: 4 / 3;
     object-fit: cover;
 }
 
 .portfolio-card div {
-    padding: 1.75rem;
+    padding: var(--card-padding);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    flex: 1;
+    justify-content: space-between;
+}
+
+.portfolio-card h3 {
+    margin: 0;
+}
+
+.portfolio-card p {
+    color: var(--muted);
+    margin: 0;
 }
 
 .section-description {
@@ -273,6 +299,17 @@ section {
     margin-top: 2rem;
 }
 
+.contact-details span {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.85rem 1.1rem;
+    background: rgba(255, 255, 255, 0.7);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow);
+    width: min(100%, 28rem);
+}
+
 .contact-link {
     color: inherit;
     text-decoration: none;
@@ -280,6 +317,10 @@ section {
 
 .contact-link--underline {
     text-decoration: underline;
+}
+
+.contact-details span a {
+    font-weight: 600;
 }
 
 .contact {
@@ -291,28 +332,29 @@ section {
 
 .contact-wrapper {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: var(--section-gap);
     align-items: start;
 }
 
 form {
     background: white;
-    border-radius: 24px;
-    padding: 2.5rem;
+    border-radius: var(--radius-lg);
+    padding: var(--card-padding);
     box-shadow: var(--shadow);
     display: grid;
-    gap: 1rem;
+    gap: 1.25rem;
 }
 
 label {
     font-weight: 600;
+    color: var(--muted);
 }
 
 input,
 textarea {
     padding: 0.85rem 1rem;
-    border-radius: 12px;
+    border-radius: var(--radius-md);
     border: 1px solid rgba(110, 129, 110, 0.35);
     font: inherit;
     resize: vertical;
@@ -361,7 +403,4 @@ footer {
         padding: 6rem 1.5rem;
     }
 
-    .portfolio-card img {
-        height: 200px;
-    }
 }


### PR DESCRIPTION
## Summary
- add reusable spacing, radius, and shadow tokens to drive consistent tile styling
- align portfolio and stat cards with shared padding, typography, and aspect ratios for balanced grids
- refresh contact details and form spacing to match the updated card visuals

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_b_68e158fd086c8326b8de7bc89245cb57