### PR TITLE
Adjust hero section layout for above-the-fold display

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     </header>
     <main id="main-content">
         <section id="home" class="hero">
-            <div>
+            <div class="hero-copy">
                 <h1>Paula Bendowska &mdash; Portrait Photographer</h1>
                 <p>
                     I’m Paula Bendowska, a destination photographer capturing heartfelt weddings, editorial portraits,

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -14,6 +14,7 @@
     --radius-md: 18px;
     --section-gap: clamp(3rem, 8vw, 6rem);
     --card-padding: clamp(1.75rem, 3vw, 2.5rem);
+    --header-height: clamp(64px, 10vw, 96px);
     font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
 }
 
@@ -114,7 +115,7 @@ nav a:focus-visible {
 }
 
 main {
-    padding-top: 5rem;
+    padding-top: var(--header-height);
 }
 
 section {
@@ -128,24 +129,36 @@ section {
 .hero {
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     column-gap: clamp(2rem, 6vw, 5rem);
-    padding-top: clamp(2rem, 8vw, 5rem);
+    padding: clamp(3rem, 9vw, 6rem) clamp(2rem, 7vw, 7rem);
+    min-height: calc(100vh - var(--header-height));
+    row-gap: clamp(2rem, 6vw, 4rem);
 }
 
 .hero h1 {
-    font-size: clamp(2.8rem, 6vw, 4.5rem);
-    margin-bottom: 1.5rem;
+    font-size: clamp(2.4rem, 5vw, 3.75rem);
+    line-height: 1.15;
+    letter-spacing: -0.01em;
+    margin: 0;
 }
 
 .hero p {
-    line-height: 1.7;
+    line-height: 1.65;
     color: var(--muted);
-    margin-bottom: 2rem;
+    margin: 0;
+}
+
+.hero-copy {
+    max-width: 32rem;
+    display: grid;
+    gap: clamp(1.25rem, 3vw, 1.75rem);
+    align-content: start;
 }
 
 .cta-group {
     display: flex;
     flex-wrap: wrap;
     gap: 1rem;
+    margin-top: 0.25rem;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- ensure the hero content stays within the initial viewport by introducing a shared header-height variable and adjusting spacing
- refine hero typography and layout for a tighter presentation of the intro copy and calls to action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e15ec29d0883268c5bcb706845d3bc