### PR TITLE
Adjust hero layout spacing and image scale

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -129,9 +129,10 @@ section {
 .hero {
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     column-gap: clamp(2rem, 6vw, 5rem);
-    padding: clamp(3rem, 9vw, 6rem) clamp(2rem, 7vw, 7rem);
-    min-height: calc(100vh - var(--header-height));
+    padding: clamp(2.5rem, 7vw, 4.5rem) clamp(2rem, 7vw, 7rem);
+    min-height: min(85vh, calc(100vh - var(--header-height)));
     row-gap: clamp(2rem, 6vw, 4rem);
+    align-content: start;
 }
 
 .hero h1 {
@@ -199,11 +200,19 @@ section {
     border-radius: var(--radius-xl);
     overflow: hidden;
     box-shadow: var(--shadow);
+    width: min(80%, 520px);
+    justify-self: center;
 }
 
 .hero-image img {
     width: 100%;
     display: block;
+}
+
+@media (min-width: 768px) {
+    .hero-image {
+        justify-self: end;
+    }
 }
 
 .section-title {


### PR DESCRIPTION
## Summary
- reduce the hero section height and adjust alignment so the home copy sits higher on the page
- scale down the hero image container to make the featured photo 20% smaller while keeping responsive alignment

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e160b8f73c8326afb9933161ea6e77