### PR TITLE
Reduce section spacing for single-screen layout

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -12,7 +12,7 @@
     --radius-xl: 32px;
     --radius-lg: 24px;
     --radius-md: 18px;
-    --section-gap: clamp(3rem, 8vw, 6rem);
+    --section-gap: clamp(1.75rem, 4vw, 3rem);
     --card-padding: clamp(1.75rem, 3vw, 2.5rem);
     --header-height: clamp(64px, 10vw, 96px);
     font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
@@ -60,7 +60,7 @@ header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1rem clamp(2rem, 6vw, 6rem);
+    padding: 0.75rem clamp(1.5rem, 5vw, 4rem);
     background: rgba(255, 249, 240, 0.92);
     backdrop-filter: blur(12px);
     z-index: 1000;
@@ -119,19 +119,17 @@ main {
 }
 
 section {
-    min-height: 100vh;
     display: grid;
-    align-items: center;
-    padding: clamp(4rem, 12vw, 8rem) clamp(2rem, 8vw, 8rem);
+    align-items: start;
+    padding: clamp(2.25rem, 7vw, 3.75rem) clamp(1.5rem, 6vw, 4.5rem);
     gap: var(--section-gap);
 }
 
 .hero {
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    column-gap: clamp(2rem, 6vw, 5rem);
-    padding: clamp(2.5rem, 7vw, 4.5rem) clamp(2rem, 7vw, 7rem);
-    min-height: min(85vh, calc(100vh - var(--header-height)));
-    row-gap: clamp(2rem, 6vw, 4rem);
+    column-gap: clamp(1.5rem, 5vw, 3.5rem);
+    padding: clamp(2rem, 6vw, 3.25rem) clamp(1.5rem, 6vw, 4.5rem);
+    row-gap: clamp(1.5rem, 5vw, 2.75rem);
     align-content: start;
 }
 
@@ -151,7 +149,7 @@ section {
 .hero-copy {
     max-width: 32rem;
     display: grid;
-    gap: clamp(1.25rem, 3vw, 1.75rem);
+    gap: clamp(1rem, 2.5vw, 1.5rem);
     align-content: start;
 }
 
@@ -200,7 +198,7 @@ section {
     border-radius: var(--radius-xl);
     overflow: hidden;
     box-shadow: var(--shadow);
-    width: min(80%, 520px);
+    width: min(70%, 420px);
     justify-self: center;
 }
 
@@ -234,7 +232,7 @@ section {
 
 .about-grid {
     display: grid;
-    gap: calc(var(--section-gap) * 0.8);
+    gap: calc(var(--section-gap) * 0.7);
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
@@ -246,7 +244,6 @@ section {
     display: grid;
     gap: 0.75rem;
     text-align: left;
-    min-height: clamp(200px, 28vw, 240px);
 }
 
 .stat h3 {
@@ -312,13 +309,13 @@ section {
 .section-description {
     max-width: 40rem;
     color: var(--muted);
-    line-height: 1.8;
+    line-height: 1.65;
 }
 
 .contact-details {
     display: grid;
-    gap: 1rem;
-    margin-top: 2rem;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
 }
 
 .contact-details span {
@@ -365,7 +362,7 @@ form {
     padding: var(--card-padding);
     box-shadow: var(--shadow);
     display: grid;
-    gap: 1.25rem;
+    gap: 1rem;
 }
 
 label {
@@ -384,7 +381,7 @@ textarea {
 }
 
 textarea {
-    min-height: 160px;
+    min-height: 120px;
 }
 
 input:focus-visible,
@@ -396,7 +393,7 @@ textarea:focus-visible {
 
 footer {
     text-align: center;
-    padding: 3rem 1rem;
+    padding: 1.75rem 1rem;
     color: rgba(47, 58, 47, 0.65);
 }
 
@@ -422,7 +419,7 @@ footer {
     }
 
     section {
-        padding: 6rem 1.5rem;
+        padding: 4rem 1.5rem;
     }
 
 }


### PR DESCRIPTION
## Summary
- tighten global spacing variables and header padding to minimize vertical layout height
- shrink hero layout gaps and supporting sections so each block fits within the viewport without scrolling

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e1623e1cd88326a0e7428276edcb17